### PR TITLE
Change top level element of unit test, etc

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/build.xml
+++ b/build.xml
@@ -11,20 +11,13 @@
 
 
  <!-- Dependencies for this project -->
- <target name="setup:deps" depends="setup:deps:base">
-  <antcall target="setup:xslutil"/>
- </target>
-
  <property name="dep.xslutil.version" value="1.0.2"/>
 
- <target name="setup:xslutil">
-  <property name="pkg" value="xslutil-${dep.xslutil.version}"/>
-  <property name="dir" value="${dir.work.xsl}/${pkg}"/>
-  <property name="url" value="https://github.com/xslet/xslutil/archive/${dep.xslutil.version}.zip"/>
-  <property name="zip" location="${dir.work.dl}/${pkg}.zip"/>
-  <property name="unzip" location="${dir}/.."/>
-  <get src="${url}" dest="${zip}"/>
-  <unzip src="${zip}" dest="${unzip}"/>
+ <target name="setup:deps" depends="setup:deps:base">
+  <antcall target="setup:xslet-lib">
+   <param name="package" value="xslutil"/>
+   <param name="version" value="${dep.xslutil.version}"/>
+  </antcall>
  </target>
 
 

--- a/res/ant/build.targets.xml
+++ b/res/ant/build.targets.xml
@@ -32,6 +32,16 @@
   </exec>
  </target>
 
+ <target name="setup:xslet-lib">
+  <property name="_pkg" value="${package}-${version}"/>
+  <property name="_dir" value="${dir.work.xsl}/${_pkg}"/>
+  <property name="_url" value="https://github.com/xslet/${package}/archive/${version}.zip"/>
+  <property name="_zip" location="${dir.work.dl}/${_pkg}.zip"/>
+  <property name="_unzip" location="${_dir}/.."/>
+  <get src="${_url}" dest="${_zip}"/>
+  <unzip src="${_zip}" dest="${_unzip}"/>
+ </target>
+
 
  <target name="build"
    description="Execute `clean`, `merge` and `deploy` tasks.">

--- a/res/xsl/merge-for-test.xsl
+++ b/res/xsl/merge-for-test.xsl
@@ -127,7 +127,7 @@
      </xsl:merge-action>
     </xsl:merge>
 
-    <xsx:template match="/describe">
+    <xsx:template match="/*">
      <xsx:variable name="_data_url" select="@data-src" />
      <html>
      <head>

--- a/src/xsl/ext/.gitkeep.xsl
+++ b/src/xsl/ext/.gitkeep.xsl
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+</xsl:stylesheet>

--- a/src/xsl/lib/.gitkeep.xsl
+++ b/src/xsl/lib/.gitkeep.xsl
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+</xsl:stylesheet>


### PR DESCRIPTION
### Changes

- [fix: change top level element of unit test to /*](https://github.com/xslet/xslt-repo-template/commit/bb55faada982851d3692ce37d723682e35db52f3)

    Changes top level element of unit test from `/describe` to `/*` to enable to use any named element.
    This PR modifies `res/xsl/merge-for-test.xsl` for this change.

- [feat: add target setup:xslet-lib](https://github.com/xslet/xslt-repo-template/commit/d296d4ef1c329cdb65fdb4ffde4ade1564f7b6e4)]

    Adds `setup:xslet-lib` target to `res/ant/build.targets.xml` file to make it easier to install xslet libraries.

- [fix: add .gitkeep.xsl into src/xsl/etc and src/xsl/lib](https://github.com/xslet/xslt-repo-template/commit/6c55c4290b6f87239f913c43e88bd8f50474ae1b)

    This change adds these directories to git repository even if these are empty.

- [chore: add .gitattributes](https://github.com/xslet/xslt-repo-template/commit/654bc9cdd9cd3e9d859ca789e5e1c6f5af58cb37)]

    (As this commit message.)

(closes #4)