### PR TITLE
Add a template for "compute/param" in res/xsl/merge-for-test.xsl

### DIFF
--- a/res/xsl/merge-for-test.xsl
+++ b/res/xsl/merge-for-test.xsl
@@ -234,6 +234,7 @@
       <div class="code computed"><xsx:value-of select="$computed" /></div>
      </div>
     </xsx:template>
+    <xsx:template match="compute/param"/>
    </xsx:stylesheet>
   </xsl:result-document>
  </xsl:template>


### PR DESCRIPTION
### Changes:

In unit tests, `<compute>` element picks values of child `<param>` elements.
This PR prevents `<compute>` to pick them.