### PR TITLE
use xsl:strip-space element, etc.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -11,7 +11,7 @@
 
 
  <!-- Dependencies for this project -->
- <property name="dep.xslutil.version" value="1.0.2"/>
+ <property name="dep.xslutil.version" value="1.0.3"/>
 
  <target name="setup:deps" depends="setup:deps:base">
   <antcall target="setup:xslet-lib">

--- a/res/ant/build.dependencies.xml
+++ b/res/ant/build.dependencies.xml
@@ -43,7 +43,7 @@
   <equals arg1="${ant.project.name}" arg2="xsldoc"/>
  </condition>
 
- <property name="dep.xsldoc.version" value="1.0.1"/>
+ <property name="dep.xsldoc.version" value="1.0.2"/>
  <property name="pkg.xsldoc" value="xsldoc-${dep.xsldoc.version}"/>
  <property name="dir.xsldoc" value="${dir.work.lib}/${pkg.xsldoc}"/>
  <property name="url.xsldoc" value="https://github.com/xslet/xsldoc/archive/${dep.xsldoc.version}.zip"/>

--- a/res/doc/unit-test.css
+++ b/res/doc/unit-test.css
@@ -7,7 +7,17 @@ html {
 
 
 body {
-  margin: 2rem;
+  margin: 0rem;
+  padding: 1rem 2rem;
+}
+
+div#passFailBar {
+  position: fixed;
+  top: 0px;
+  left: 0px;
+  height: 5px;
+  width: 100vw;
+  background-color: #bbb;
 }
 
 

--- a/res/doc/unit-test.js
+++ b/res/doc/unit-test.js
@@ -7,3 +7,13 @@ function showHideComparison(switcher) {
   target.classList.toggle('show');
   target.classList.toggle('hide');
 }
+
+window.addEventListener('DOMContentLoaded', () => {
+  const passFailBar = document.getElementById('passFailBar');
+  const failIt = document.querySelector('section.it.fail');
+  if (failIt) {
+    passFailBar.style.backgroundColor = '#f00';
+  } else {
+    passFailBar.style.backgroundColor = '#0f0';
+  }
+});

--- a/res/xsl/merge-for-dist.xsl
+++ b/res/xsl/merge-for-dist.xsl
@@ -90,6 +90,8 @@
      </xsl:merge>
     </xsl:if>
 
+    <xsx:strip-space elements="*" />
+
     <xsl:merge><!-- Merge `xsl:param`s -->
      <xsl:merge-source for-each-source="uri-collection($srcdir)"
       select="xsl:stylesheet/xsl:param">

--- a/res/xsl/merge-for-doc.xsl
+++ b/res/xsl/merge-for-doc.xsl
@@ -104,6 +104,8 @@
      </xsl:merge>
     </xsl:if>
 
+    <xsx:strip-space elements="*" />
+
     <xsl:merge><!-- Merge `xsl:param`s and these comments -->
      <xsl:merge-source for-each-source="uri-collection($srcdir)"
       select="xsl:stylesheet/xsl:param|xsl:stylesheet/comment()[following-sibling::*[1]/name() = 'xsl:param']">

--- a/res/xsl/merge-for-test.xsl
+++ b/res/xsl/merge-for-test.xsl
@@ -139,6 +139,7 @@
       <script src="./unit-test.js"></script>
      </head>
      <body>
+      <div id="passFailBar"/>
       <h1><xsx:value-of select="@title" /></h1>
       <xsx:apply-templates select="describe|it">
        <xsx:with-param name="data_url" select="$_data_url" />

--- a/res/xsl/merge-for-test.xsl
+++ b/res/xsl/merge-for-test.xsl
@@ -54,6 +54,8 @@
      </xsl:merge>
     </xsl:if>
 
+    <xsx:strip-space elements="*" />
+
     <xsl:merge>
      <xsl:merge-source for-each-source="uri-collection($srcdir)"
        select="xsl:stylesheet/xsl:param">


### PR DESCRIPTION
### Changes

- [upgrade: bump xslutil from 1.0.2 to 1.0.3.](https://github.com/xslet/xslt-repo-template/commit/f192fde9a111c288677f92952ed204dfe050a2ec)

    This PR changes xslutil version written in `build.xml`.

- [upgrade: bump xsldoc from 1.0.1 to 1.0.2.](https://github.com/xslet/xslt-repo-template/commit/976e491799f3ff4410bed71728b2137b05d6103b)

    This PR changes xsldoc version written in `res/ant/build.dependencies.xml`.

- [fix: use xsl:strip-space element.](https://github.com/xslet/xslt-repo-template/commit/06f82204573e3094098ccc58c70a7a7fc7dd8865)

    This change displays a green or red bar on top of unit test pages which indicates whether all of tests in the page are passed or not.

- [feat: add pass-fail bar in unit test pages](https://github.com/xslet/xslt-repo-template/commit/6b88ccbfe43f6d0243d0689d100de4dbe86814ba)

    This change insert `<xsl:strip-space>` XSLT element in produced XSL files.